### PR TITLE
Aufnahme von Link in Ausgabe von Literatur-Einträge

### DIFF
--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -140,6 +140,10 @@
     "de": "Permalink",
     "en": "Persistent Link"
   },
+  "link": {
+    "de": "Link",
+    "en": "Link"
+  },
   "objectName": {
     "de": "FR (1978) Nr.",
     "en": "FR (1978) Nr."

--- a/src/_layouts/components/sources.11ty.js
+++ b/src/_layouts/components/sources.11ty.js
@@ -36,6 +36,7 @@ exports.getSources = (eleventy, { content }, langCode, hasGrayBackground = false
         ${item && item.link ? getRow(item.link, 'permalink') : ''}
         ${item && item.pageNumbers ? getRow(item.pageNumbers, 'pages') : ''}
         ${getRow(alternateNumbers.join(', '), 'alternativeNumbers')}
+        ${item && item.copyright ? getRow(item.copyright, 'link') : ''}
       </table>
     `;
   };


### PR DESCRIPTION
Gunnar hatte mir geschrieben, dass bei den Literaturdaten in den neuen Gemäldeseiten noch die Ausgabe einer URL fehlt, sofern eine gegeben.

![20220114Unbenannt-1](https://user-images.githubusercontent.com/1864692/149514287-003434e7-5b08-4f36-9136-64cfe31e4c1f.jpg)

Diese ist unter der Eigenschaft `copyright` zu finden. Wird auch im TMS über das Copyright-Feld gepflegt.
Idealerweise sollte die URL noch linkified werden. @cnoss Da müsstest du vllt. mal schauen, wie du das gerne im Code haben möchtest. Meine hier speziell die `getRow`-Funktion in der `getLiteraturDetails`-Funktion.