### PR TITLE
M store user interaction

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -226,7 +226,7 @@ const getGraphicsRealObjectsCollection = (lang) => {
 
 const getGraphicsVirtualObjectsCollection = (lang) => {
   const graphicsVirtualObjectsForLang = graphicsVirtualObjectData[lang];
-  const devObjects = ["ANO_H-NONE-001", "DE_SAOH_2000-3a", "ANO_H-NONE-002", "ANO_H-NONE-017","ANO_HVI-7-6", "HBG_HVI-8_7-4", "HB_HIV-259-595"];
+  const devObjects = ["ANO_HVI-7-6","ANO_H-NONE-001", "DE_SAOH_2000-3a", "ANO_H-NONE-002", "ANO_H-NONE-017","ANO_HVI-7-6", "HBG_HVI-8_7-4", "HB_HIV-259-595"];
   
   const graphicsVirtualObjects = process.env.ELEVENTY_ENV === 'production'
     ? graphicsVirtualObjectsForLang.items

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,23 @@
 # Changelog Cranach Artefacts
 
+## v0.5.3
+Mit dieser Version werden folgende Fehler behoben/ Funktionen/ Inhalte bereit gestellt:
+- Permalinks sind jetzt klickbar
+- "Erhaltungszustand" umbenannt in "Zustand / Auflage“ (State/ Edition) 
+- Information "Druckgrafik" wurde entfernt und die restliche Informationen wird nun mit Komma getrennt angezeigt
+- neues Feld "Datierung" wurde integriert
+- Nutzerinteraktionen werden gespeichert und beim Reload wieder hergestellt.
+- Folgende Abbildungen/ Metadaten wurden aktualisiert:
+  - CH_MAS_A1950_FR-none
+  - DE_HSBBW_Ia20_FR-none
+  - DE_LHW_G163_FR-none
+  - DE_LHW_G16_FR-none
+  - DE_SAOH_2000-3a_FR-none
+  - DE_WSE_M0065
+  - DE_smbGG_637_FR190A
+  - PRIVATE_NONE-P411_FR-none
+  - SE_NMS_5016_FR189-190B
+  - US_MMANY_55-220-2_FR314F
 ## v0.5.2
 Mit dieser Version werden folgende Fehler behoben/ Funktionen/ Inhalte bereit gestellt:
 - Sprachwähler Icon wird jetzt auf allen Systemen korrekt angezeigt.

--- a/src/_data/cda-filters.de.json
+++ b/src/_data/cda-filters.de.json
@@ -331,6 +331,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.augsburg.augsburg_5",
+                                        "text": "Staats- und Stadtbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.augsburg.augsburg_4",
                                         "text": "Staatsgalerie Augsburg, Katharinenkirche",
                                         "children": []
@@ -365,6 +370,11 @@
                                     {
                                         "id": "collection_repository.country.germany.bamberg.bamberg_1",
                                         "text": "Dom St. Peter und St. Georg",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.bamberg.bamberg_3",
+                                        "text": "Staatsbibliothek",
                                         "children": []
                                     },
                                     {
@@ -477,6 +487,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.coburg.coburg_3",
+                                        "text": "Landesbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.coburg.coburg_2",
                                         "text": "Stiftung der Herzog von Sachsen-Coburg und Gotha'schen Familie",
                                         "children": []
@@ -544,6 +559,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.dresden.dresden_4",
+                                        "text": "S\u00e4chsische Landesbibliothek \u2013 Staats- und Universit\u00e4tsbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.dresden.dresden_2",
                                         "text": "Stadtmuseum",
                                         "children": []
@@ -562,8 +582,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.eichstaett",
-                                "text": "Eichst\u00e4tt, Bisch\u00f6flicher Stuhl",
-                                "children": []
+                                "text": "Eichst\u00e4tt",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.eichstaett_1",
+                                        "text": "Bisch\u00f6flicher Stuhl",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.eichstaett_2",
+                                        "text": "Eichst\u00e4tt, Universit\u00e4tsbibliothek Eichst\u00e4tt-Ingolstadt",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.eisenach",
@@ -588,6 +619,11 @@
                                         "id": "collection_repository.country.germany.erfurt.erfurt_2",
                                         "text": "Dom St. Marien",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.erfurt.erfurt_3",
+                                        "text": "Forschungsbibliothek der Universit\u00e4t Erfurt",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -598,8 +634,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.frankfurt",
-                                "text": "Frankfurt, St\u00e4del Museum",
-                                "children": []
+                                "text": "Frankfurt a.M.",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.frankfurt_2",
+                                        "text": "Philosophisch-Theologische Hochschule Sankt Georgen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.frankfurt_1",
+                                        "text": "St\u00e4del Museum",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.freiberg",
@@ -628,7 +675,23 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.goerlitz",
-                                "text": "G\u00f6rlitz, Kulturhistorisches Museum G\u00f6rlitzer, Kunstsammlung",
+                                "text": "G\u00f6rlitz",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.goerlitz_1",
+                                        "text": "Kulturhistorisches Museum G\u00f6rlitzer, Kunstsammlung",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.goerlitz_2",
+                                        "text": "Oberlausitzische Bibliothek der Wissenschaften bei den St\u00e4dtischen Sammlungen f\u00fcr Geschichte und Kultur",
+                                        "children": []
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "collection_repository.country.germany.goettingen",
+                                "text": "G\u00f6ttingen, Nieders\u00e4chsische Staats- und Universit\u00e4tsbibliothek",
                                 "children": []
                             },
                             {
@@ -661,8 +724,18 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.halle.halle_3",
+                                        "text": "Frankesche Stiftungen",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.halle.halle_2",
                                         "text": "Kulturstiftung Sachsen-Anhalt - Kunstmuseum Moritzburg",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.halle.halle_4",
+                                        "text": "Universit\u00e4ts- und Landesbibliothek Sachsen-Anhalt",
                                         "children": []
                                     }
                                 ]
@@ -753,8 +826,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.karlsruhe",
-                                "text": "Karlsruhe, Staatliche Kunsthalle",
-                                "children": []
+                                "text": "Karlsruhe",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.karlsruhe_2",
+                                        "text": "Landesbibliothek",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.karlsruhe_1",
+                                        "text": "Staatliche Kunsthalle",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.kassel",
@@ -849,6 +933,11 @@
                                         "id": "collection_repository.country.germany.leipzig.leipzig_4",
                                         "text": "Stadtgeschichtliches Museum",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.leipzig.leipzig_5",
+                                        "text": "Universit\u00e4tsbibliothek",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -924,6 +1013,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.munich.munich_4",
+                                        "text": "Bayerische Staatsbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.munich.munich_2",
                                         "text": "Bayerisches Nationalmuseum",
                                         "children": []
@@ -931,6 +1025,11 @@
                                     {
                                         "id": "collection_repository.country.germany.munich.munich_3",
                                         "text": "Staatliche Graphische Sammlung M\u00fcnchen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.munich.munich_5",
+                                        "text": "Universit\u00e4tsbibliothek der LMU",
                                         "children": []
                                     }
                                 ]
@@ -992,9 +1091,25 @@
                                 "children": []
                             },
                             {
-                                "id": "collection_repository.country.germany.regensburg",
-                                "text": "Regensburg, Historisches Museum",
+                                "id": "collection_repository.country.germany.oschatz",
+                                "text": "Oschatz, Stadt- und Waagenmuseum",
                                 "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.germany.regensburg",
+                                "text": "Regensburg",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.regensburg_1",
+                                        "text": "Historisches Museum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.regensburg_2",
+                                        "text": "Staatliche Bibliothek",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.remagen",
@@ -1004,6 +1119,11 @@
                             {
                                 "id": "collection_repository.country.germany.rochlitz",
                                 "text": "Rochlitz, Ev.-Luth. Kirchgemeinde",
+                                "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.germany.rostock",
+                                "text": "Rostock, Universit\u00e4tsbibliothek",
                                 "children": []
                             },
                             {
@@ -1037,19 +1157,25 @@
                                 "children": []
                             },
                             {
-                                "id": "collection_repository.country.germany.oschatz",
-                                "text": "Stadt- und Waagenmuseum Oschatz",
-                                "children": []
-                            },
-                            {
                                 "id": "collection_repository.country.germany.bad_windsheim",
                                 "text": "Stadtarchiv und historische Stadtbibliothek Bad Windsheim",
                                 "children": []
                             },
                             {
                                 "id": "collection_repository.country.germany.stuttgart",
-                                "text": "Stuttgart, Staatsgalerie",
-                                "children": []
+                                "text": "Stuttgart",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.stuttgart_1",
+                                        "text": "Staatsgalerie",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.stuttgart_2",
+                                        "text": "W\u00fcrttembergische Landesbibliothek",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.nischwitz",
@@ -1087,6 +1213,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.weimar.weimar_3",
+                                        "text": "Herzogin Anna Amalia Bibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.weimar.weimar_2",
                                         "text": "Museen der Klassik Stiftung",
                                         "children": []
@@ -1121,6 +1252,11 @@
                                         "id": "collection_repository.country.germany.wittenberg.wittenberg_3",
                                         "text": "Lutherhaus",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.wittenberg.wittenberg_4",
+                                        "text": "Reformationsgeschichtliche Forschungsbibliothek",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -1139,6 +1275,11 @@
                                         "children": []
                                     }
                                 ]
+                            },
+                            {
+                                "id": "collection_repository.country.germany.wolfegg",
+                                "text": "Wolfegg, Kunstsammlungen der F\u00fcrsten zu Waldburg-Wolfegg",
+                                "children": []
                             },
                             {
                                 "id": "collection_repository.country.germany.wolfenbuettel",
@@ -1183,6 +1324,11 @@
                                     {
                                         "id": "collection_repository.country.germany.zwickau.zwickau_3",
                                         "text": "Kunstsammlungen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.zwickau.zwickau_4",
+                                        "text": "Ratsschulbibliothek",
                                         "children": []
                                     },
                                     {
@@ -1288,8 +1434,24 @@
                             },
                             {
                                 "id": "collection_repository.country.france.strasbourg",
-                                "text": "Strasbourg, Mus\u00e9e des Beaux-Arts",
-                                "children": []
+                                "text": "Strasbourg",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_2",
+                                        "text": "Biblioth\u00e8que nationale et universitaire",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_3",
+                                        "text": "Cabinet des estampes et dessins",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_1",
+                                        "text": "Mus\u00e9e des Beaux-Arts",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.france.toulouse",
@@ -1507,8 +1669,19 @@
                             },
                             {
                                 "id": "collection_repository.country.netherlands.amsterdam",
-                                "text": "Amsterdam, Rijksmuseum",
-                                "children": []
+                                "text": "Amsterdam",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.netherlands.amsterdam_1",
+                                        "text": "Rijksmuseum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.netherlands.amsterdam_2",
+                                        "text": "Vrije Universiteit Bibliotheek Amsterdam",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.netherlands.enschede",
@@ -1661,6 +1834,11 @@
                                     {
                                         "id": "collection_repository.country.austria.vienna.vienna_3",
                                         "text": "\u00d6sterreichische Galerie Belvedere",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.austria.vienna.vienna_6",
+                                        "text": "\u00d6sterreichische Nationalbibliothek",
                                         "children": []
                                     }
                                 ]
@@ -1863,7 +2041,23 @@
                             },
                             {
                                 "id": "collection_repository.country.switzerland.bern",
-                                "text": "Bern, Kunstmuseum",
+                                "text": "Bern",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.switzerland.bern_1",
+                                        "text": "Kunstmuseum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.bern_2",
+                                        "text": "Universit\u00e4tsbibliothek - Bibliothek M\u00fcnstergasse",
+                                        "children": []
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "collection_repository.country.switzerland.chur",
+                                "text": "Chur, Kantonsbibliothek",
                                 "children": []
                             },
                             {
@@ -1874,6 +2068,11 @@
                             {
                                 "id": "collection_repository.country.switzerland.schaffhausen",
                                 "text": "Schaffhausen, Museum zu Allerheiligen",
+                                "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.switzerland.st_gallen",
+                                "text": "St. Gallen, Kantonsbibliothek",
                                 "children": []
                             },
                             {
@@ -1894,8 +2093,24 @@
                             },
                             {
                                 "id": "collection_repository.country.switzerland.zurich",
-                                "text": "Z\u00fcrich, Kunsthaus",
-                                "children": []
+                                "text": "Z\u00fcrich",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_2",
+                                        "text": "Eidgen\u00f6ssische Technische Hochschule",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_1",
+                                        "text": "Kunsthaus",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_3",
+                                        "text": "Zentralbibliothek",
+                                        "children": []
+                                    }
+                                ]
                             }
                         ]
                     },
@@ -2088,8 +2303,19 @@
                             },
                             {
                                 "id": "collection_repository.country.america.atlanta",
-                                "text": "Atlanta, High Museum of Art",
-                                "children": []
+                                "text": "Atlanta",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.america.atlanta_1",
+                                        "text": "High Museum of Art",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.america.atlanta_2",
+                                        "text": "Pitts Theology Library, Emory University",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.america.baltimore",
@@ -2391,6 +2617,11 @@
                                 "children": [
                                     {
                                         "id": "collection_repository.country.britain.london.london_1",
+                                        "text": "British Museum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.britain.london.london_5",
                                         "text": "British Museum",
                                         "children": []
                                     },

--- a/src/_data/cda-filters.en.json
+++ b/src/_data/cda-filters.en.json
@@ -280,6 +280,11 @@
                                         "id": "collection_repository.country.austria.vienna.vienna_3",
                                         "text": "\u00d6sterreichische Galerie Belvedere",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.austria.vienna.vienna_6",
+                                        "text": "\u00d6sterreichische Nationalbibliothek",
+                                        "children": []
                                     }
                                 ]
                             }
@@ -605,8 +610,24 @@
                             },
                             {
                                 "id": "collection_repository.country.france.strasbourg",
-                                "text": "Strasbourg, Mus\u00e9e des Beaux-Arts",
-                                "children": []
+                                "text": "Strasbourg",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_2",
+                                        "text": "Biblioth\u00e8que nationale et universitaire",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_3",
+                                        "text": "Cabinet des estampes et dessins",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.france.strasbourg_1",
+                                        "text": "Mus\u00e9e des Beaux-Arts",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.france.toulouse",
@@ -702,6 +723,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.augsburg.augsburg_5",
+                                        "text": "Staats- und Stadtbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.augsburg.augsburg_4",
                                         "text": "Staatsgalerie Augsburg, Katharinenkirche",
                                         "children": []
@@ -736,6 +762,11 @@
                                     {
                                         "id": "collection_repository.country.germany.bamberg.bamberg_1",
                                         "text": "Dom St. Peter und St. Georg",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.bamberg.bamberg_3",
+                                        "text": "Staatsbibliothek",
                                         "children": []
                                     },
                                     {
@@ -848,6 +879,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.coburg.coburg_3",
+                                        "text": "Landesbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.coburg.coburg_2",
                                         "text": "Stiftung der Herzog von Sachsen-Coburg und Gotha'schen Familie",
                                         "children": []
@@ -920,6 +956,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.dresden.dresden_4",
+                                        "text": "S\u00e4chsische Landesbibliothek \u2013 Staats- und Universit\u00e4tsbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.dresden.dresden_2",
                                         "text": "Stadtmuseum",
                                         "children": []
@@ -938,8 +979,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.eichstaett",
-                                "text": "Eichst\u00e4tt, Bisch\u00f6flicher Stuhl",
-                                "children": []
+                                "text": "Eichst\u00e4tt",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.eichstaett_1",
+                                        "text": "Bisch\u00f6flicher Stuhl",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.eichstaett_2",
+                                        "text": "Eichst\u00e4tt, Universit\u00e4tsbibliothek Eichst\u00e4tt-Ingolstadt",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.eisenach",
@@ -964,6 +1016,11 @@
                                         "id": "collection_repository.country.germany.erfurt.erfurt_2",
                                         "text": "Dom St. Marien",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.erfurt.erfurt_3",
+                                        "text": "Forschungsbibliothek der Universit\u00e4t Erfurt",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -974,8 +1031,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.frankfurt",
-                                "text": "Frankfurt, St\u00e4del Museum",
-                                "children": []
+                                "text": "Frankfurt a.M.",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.frankfurt_2",
+                                        "text": "Philosophisch-Theologische Hochschule Sankt Georgen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.frankfurt_1",
+                                        "text": "St\u00e4del Museum",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.freiberg",
@@ -1004,7 +1072,23 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.goerlitz",
-                                "text": "G\u00f6rlitz, Kulturhistorisches Museum G\u00f6rlitzer, Kunstsammlung",
+                                "text": "G\u00f6rlitz",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.goerlitz_1",
+                                        "text": "Kulturhistorisches Museum G\u00f6rlitzer, Kunstsammlung",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.goerlitz_2",
+                                        "text": "Oberlausitzische Bibliothek der Wissenschaften bei den St\u00e4dtischen Sammlungen f\u00fcr Geschichte und Kultur",
+                                        "children": []
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "collection_repository.country.germany.goettingen",
+                                "text": "G\u00f6ttingen, Nieders\u00e4chsische Staats- und Universit\u00e4tsbibliothek",
                                 "children": []
                             },
                             {
@@ -1037,8 +1121,18 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.halle.halle_3",
+                                        "text": "Frankesche Stiftungen",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.halle.halle_2",
                                         "text": "Kulturstiftung Sachsen-Anhalt - Kunstmuseum Moritzburg",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.halle.halle_4",
+                                        "text": "Universit\u00e4ts- und Landesbibliothek Sachsen-Anhalt",
                                         "children": []
                                     }
                                 ]
@@ -1129,8 +1223,19 @@
                             },
                             {
                                 "id": "collection_repository.country.germany.karlsruhe",
-                                "text": "Karlsruhe, Staatliche Kunsthalle",
-                                "children": []
+                                "text": "Karlsruhe",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.karlsruhe_2",
+                                        "text": "Landesbibliothek",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.karlsruhe_1",
+                                        "text": "Staatliche Kunsthalle",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.kassel",
@@ -1220,6 +1325,11 @@
                                         "id": "collection_repository.country.germany.leipzig.leipzig_4",
                                         "text": "Stadtgeschichtliches Museum",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.leipzig.leipzig_5",
+                                        "text": "Universit\u00e4tsbibliothek",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -1305,6 +1415,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.munich.munich_4",
+                                        "text": "Bayerische Staatsbibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.munich.munich_2",
                                         "text": "Bayerisches Nationalmuseum",
                                         "children": []
@@ -1312,6 +1427,11 @@
                                     {
                                         "id": "collection_repository.country.germany.munich.munich_3",
                                         "text": "Staatliche Graphische Sammlung M\u00fcnchen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.munich.munich_5",
+                                        "text": "Universit\u00e4tsbibliothek der LMU",
                                         "children": []
                                     }
                                 ]
@@ -1363,9 +1483,25 @@
                                 "children": []
                             },
                             {
-                                "id": "collection_repository.country.germany.regensburg",
-                                "text": "Regensburg, Historisches Museum",
+                                "id": "collection_repository.country.germany.oschatz",
+                                "text": "Oschatz, Stadt- und Waagenmuseum",
                                 "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.germany.regensburg",
+                                "text": "Regensburg",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.regensburg_1",
+                                        "text": "Historisches Museum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.regensburg_2",
+                                        "text": "Staatliche Bibliothek",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.remagen",
@@ -1375,6 +1511,11 @@
                             {
                                 "id": "collection_repository.country.germany.rochlitz",
                                 "text": "Rochlitz, Ev.-Luth. Kirchgemeinde",
+                                "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.germany.rostock",
+                                "text": "Rostock, Universit\u00e4tsbibliothek",
                                 "children": []
                             },
                             {
@@ -1408,19 +1549,25 @@
                                 "children": []
                             },
                             {
-                                "id": "collection_repository.country.germany.oschatz",
-                                "text": "Stadt- und Waagenmuseum Oschatz",
-                                "children": []
-                            },
-                            {
                                 "id": "collection_repository.country.germany.bad_windsheim",
                                 "text": "Stadtarchiv und historische Stadtbibliothek Bad Windsheim",
                                 "children": []
                             },
                             {
                                 "id": "collection_repository.country.germany.stuttgart",
-                                "text": "Stuttgart, Staatsgalerie",
-                                "children": []
+                                "text": "Stuttgart",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.germany.stuttgart_1",
+                                        "text": "Staatsgalerie",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.stuttgart_2",
+                                        "text": "W\u00fcrttembergische Landesbibliothek",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.germany.nischwitz",
@@ -1458,6 +1605,11 @@
                                         "children": []
                                     },
                                     {
+                                        "id": "collection_repository.country.germany.weimar.weimar_3",
+                                        "text": "Herzogin Anna Amalia Bibliothek",
+                                        "children": []
+                                    },
+                                    {
                                         "id": "collection_repository.country.germany.weimar.weimar_2",
                                         "text": "Museen der Klassik Stiftung",
                                         "children": []
@@ -1492,6 +1644,11 @@
                                         "id": "collection_repository.country.germany.wittenberg.wittenberg_3",
                                         "text": "Lutherhaus",
                                         "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.wittenberg.wittenberg_4",
+                                        "text": "Reformationsgeschichtliche Forschungsbibliothek",
+                                        "children": []
                                     }
                                 ]
                             },
@@ -1510,6 +1667,11 @@
                                         "children": []
                                     }
                                 ]
+                            },
+                            {
+                                "id": "collection_repository.country.germany.wolfegg",
+                                "text": "Wolfegg, Kunstsammlungen der F\u00fcrsten zu Waldburg-Wolfegg",
+                                "children": []
                             },
                             {
                                 "id": "collection_repository.country.germany.wolfenbuettel",
@@ -1554,6 +1716,11 @@
                                     {
                                         "id": "collection_repository.country.germany.zwickau.zwickau_3",
                                         "text": "Kunstsammlungen",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.germany.zwickau.zwickau_4",
+                                        "text": "Ratsschulbibliothek",
                                         "children": []
                                     },
                                     {
@@ -1742,8 +1909,19 @@
                             },
                             {
                                 "id": "collection_repository.country.netherlands.amsterdam",
-                                "text": "Amsterdam, Rijksmuseum",
-                                "children": []
+                                "text": "Amsterdam",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.netherlands.amsterdam_1",
+                                        "text": "Rijksmuseum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.netherlands.amsterdam_2",
+                                        "text": "Vrije Universiteit Bibliotheek Amsterdam",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.netherlands.enschede",
@@ -2041,7 +2219,23 @@
                             },
                             {
                                 "id": "collection_repository.country.switzerland.bern",
-                                "text": "Bern, Kunstmuseum",
+                                "text": "Bern",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.switzerland.bern_1",
+                                        "text": "Kunstmuseum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.bern_2",
+                                        "text": "Universit\u00e4tsbibliothek - Bibliothek M\u00fcnstergasse",
+                                        "children": []
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "collection_repository.country.switzerland.chur",
+                                "text": "Chur, Kantonsbibliothek",
                                 "children": []
                             },
                             {
@@ -2052,6 +2246,11 @@
                             {
                                 "id": "collection_repository.country.switzerland.schaffhausen",
                                 "text": "Schaffhausen, Museum zu Allerheiligen",
+                                "children": []
+                            },
+                            {
+                                "id": "collection_repository.country.switzerland.st_gallen",
+                                "text": "St. Gallen, Kantonsbibliothek",
                                 "children": []
                             },
                             {
@@ -2072,8 +2271,24 @@
                             },
                             {
                                 "id": "collection_repository.country.switzerland.zurich",
-                                "text": "Z\u00fcrich, Kunsthaus",
-                                "children": []
+                                "text": "Z\u00fcrich",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_2",
+                                        "text": "Eidgen\u00f6ssische Technische Hochschule",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_1",
+                                        "text": "Kunsthaus",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.switzerland.zurich_3",
+                                        "text": "Zentralbibliothek",
+                                        "children": []
+                                    }
+                                ]
                             }
                         ]
                     },
@@ -2117,6 +2332,11 @@
                                 "children": [
                                     {
                                         "id": "collection_repository.country.britain.london.london_1",
+                                        "text": "British Museum",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.britain.london.london_5",
                                         "text": "British Museum",
                                         "children": []
                                     },
@@ -2175,8 +2395,19 @@
                             },
                             {
                                 "id": "collection_repository.country.america.atlanta",
-                                "text": "Atlanta, High Museum of Art",
-                                "children": []
+                                "text": "Atlanta",
+                                "children": [
+                                    {
+                                        "id": "collection_repository.country.america.atlanta_1",
+                                        "text": "High Museum of Art",
+                                        "children": []
+                                    },
+                                    {
+                                        "id": "collection_repository.country.america.atlanta_2",
+                                        "text": "Pitts Theology Library, Emory University",
+                                        "children": []
+                                    }
+                                ]
                             },
                             {
                                 "id": "collection_repository.country.america.baltimore",

--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -35,6 +35,10 @@
     "de": "Druckzustand, Version",
     "en": "Condition"
   },
+  "stateAndEdition": {
+    "de": "Zustand / Auflage",
+    "en": "State / Edition"
+  },
   "dating": {
     "de": "Datierung",
     "en": "Dating"

--- a/src/_layouts/components/condition.11ty.js
+++ b/src/_layouts/components/condition.11ty.js
@@ -1,6 +1,7 @@
 exports.getCondition = (eleventy, { content }, langCode) => {
-  const conditionData = `${content.classification.classification}; ${content.classification.condition}`;
-  const label = eleventy.translate('condition', langCode);
+  const condition = content.classification.condition.replace(/\n|\r/, ", ");
+  const conditionData = `${condition}`;
+  const label = eleventy.translate('stateAndEdition', langCode);
   return !content.classification.classification ? '' : `
     <dl id="conditionData" class="definition-list is-grid">
       <dt class="definition-list__term">${label}</dt>

--- a/src/_layouts/components/condition.11ty.js
+++ b/src/_layouts/components/condition.11ty.js
@@ -1,5 +1,5 @@
 exports.getCondition = (eleventy, { content }, langCode) => {
-  const condition = content.classification.condition.replace(/\n|\r/, ", ");
+  const condition = content.classification.condition.replace(/\n|\r/, ', ');
   const conditionData = `${condition}`;
   const label = eleventy.translate('stateAndEdition', langCode);
   return !content.classification.classification ? '' : `

--- a/src/_layouts/components/graphic-real-object.11ty.js
+++ b/src/_layouts/components/graphic-real-object.11ty.js
@@ -22,6 +22,7 @@ const additionalTextInformationSnippet = require('./additional-text-information.
 const referencesSnippet = require('./references.11ty');
 const conditionSnippet = require('./condition.11ty');
 const navigationSnippet = require('./navigation.11ty');
+const datingSnippet = require('./dating.11ty');
 
 const ART_TECH_EXAMINATION = 'ArtTechExamination';
 const CONDITION_REPORT = 'ConditionReport';
@@ -81,6 +82,7 @@ exports.getRealObject = function (eleventy, pageData, langCode, masterData) {
   const condition = conditionSnippet.getCondition(eleventy, data, langCode);
   const medium = mediumSnippet.getMediumOfGraphic(eleventy, data, langCode);
   const shortDescription = descriptionSnippet.getShortDescription(eleventy, data, langCode);
+  const dating = datingSnippet.getDating(eleventy, data, langCode);
 
   const cranachCollectBaseUrl = eleventy.getCranachCollectBaseUrl();
   const cranachCollectScript = config.cranachCollect.script;
@@ -124,6 +126,7 @@ exports.getRealObject = function (eleventy, pageData, langCode, masterData) {
           <div class="explore-content">
             <div class="block">
               ${condition}
+              ${dating}
               ${medium}
               ${shortDescription}
               ${dimensions}

--- a/src/_layouts/components/identification.11ty.js
+++ b/src/_layouts/components/identification.11ty.js
@@ -12,7 +12,7 @@ const kklGroupLink = (eleventy, kklNr, langCode) => {
 exports.getPermalink = (eleventy, url, langCode) => `
     <dl class="definition-list is-grid">
       <dt class="definition-list__term">${eleventy.translate('permalink', langCode)}</dt>
-      <dd class="definition-list__definition" data-clipable-content="${url}">${url}</dd>
+      <dd class="definition-list__definition" data-clipable-content="${url}"><a href="${url}">${url}</a></dd>
     </dl>
   `;
 
@@ -69,7 +69,7 @@ exports.getIds = (eleventy, { content }, langCode) => {
     ${hollsteinNrSnippet}
     ${bartschNrSnippet}
     <dt class="definition-list__term">${eleventy.translate('permalink', langCode)}</dt>
-    <dd class="definition-list__definition" data-clipable-content="${content.url}">${content.url}</dd>
+    <dd class="definition-list__definition" data-clipable-content="${content.url}"><a href="${content.url}">${content.url}</a></dd>
   </dl>
   `;
 };


### PR DESCRIPTION
## v0.5.3
Mit dieser Version werden folgende Fehler behoben/ Funktionen/ Inhalte bereit gestellt:
- Permalinks sind jetzt klickbar
- "Erhaltungszustand" umbenannt in "Zustand / Auflage“ (State/ Edition) 
- Information "Druckgrafik" wurde entfernt und die restliche Informationen wird nun mit Komma getrennt angezeigt
- neues Feld "Datierung" wurde integriert
- Nutzerinteraktionen werden gespeichert und beim Reload wieder hergestellt.
- Folgende Abbildungen/ Metadaten wurden aktualisiert:
  - CH_MAS_A1950_FR-none
  - DE_HSBBW_Ia20_FR-none
  - DE_LHW_G163_FR-none
  - DE_LHW_G16_FR-none
  - DE_SAOH_2000-3a_FR-none
  - DE_WSE_M0065
  - DE_smbGG_637_FR190A
  - PRIVATE_NONE-P411_FR-none
  - SE_NMS_5016_FR189-190B
  - US_MMANY_55-220-2_FR314F