### PR TITLE
Display of materials/techniques in drawings

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -615,7 +615,7 @@ module.exports = function (eleventyConfig) {
     return connectedObjects.shift();
   });  
 
-  eleventyConfig.addJavaScriptFunction("getRemarkDataTable", (objectData, mode = 'full') => {
+  eleventyConfig.addJavaScriptFunction("getRemarkDataTable", (objectData, mode = 'full', asTable = true) => {
 
     const { content } = objectData;
     const { title } = objectData;
@@ -624,12 +624,23 @@ module.exports = function (eleventyConfig) {
     const { id } = objectData;
     const { additionalCellClass } = objectData;
 
+
+
     const rows = content.map(item => {
       if(!item.remark) return;
 
       const remarkData = item.remark.match(/\[(.*?)\]\((.*?)\)/) 
         ? item.remark.replace(/\[(.*?)\]\((.*?)\)/g, '<a class="link-to-source" href="$2">[$1]</a>') 
         : item.remark;
+
+      if (asTable === false) { 
+        if (!item.remark) return '';
+        return ` 
+          <p>${item.text}</p>
+          ${markdownify(remarkData, mode)}
+        ` 
+      }
+         
       const remark = item.remark ? `<td class="info-table__remark">${markdownify(remarkData, mode)}</td>` : '<td class="info-table__remark">-</td>';
 
       return `
@@ -642,9 +653,7 @@ module.exports = function (eleventyConfig) {
         class="additional-content js-additional-content"
         data-is-additional-content-to="${isAdditionalContentTo}">
         <h2 class="additional-content__title js-collapse-additional-content has-interaction">${title}</h2>
-        <table class="info-table additional-content__table">
-          ${rows.join("")}
-        </table>
+        ${asTable === true ? `<table class="info-table additional-content__table">${rows.join("")}</table>` : rows.join("")}
       </div>
     `;
   });

--- a/src/_layouts/components/medium.11ty.js
+++ b/src/_layouts/components/medium.11ty.js
@@ -12,7 +12,7 @@ exports.getMediumOfPainting = (eleventy, { content }, langCode) => {
     title: label,
     context: prefix,
   };
-  const mediumTable = hasAdditionalContent ? eleventy.getRemarkDataTable(remarkDataTableData) : '';
+  const mediumTable = hasAdditionalContent ? eleventy.getRemarkDataTable(remarkDataTableData, 'full', false) : '';
   return !medium ? '' : `
     <div class="has-tight-separator">
       <div id="${prefix}-subtitle">
@@ -37,7 +37,7 @@ exports.getMediumOfGraphic = (eleventy, { content }, langCode) => {
     title: label,
     context: prefix,
   };
-  const mediumTable = hasAdditionalContent ? eleventy.getRemarkDataTable(remarkDataTableData) : '';
+  const mediumTable = hasAdditionalContent ? eleventy.getRemarkDataTable(remarkDataTableData, 'full', false) : '';
   return !medium ? '' : `
     <dl id="${prefix}-mediumData" class="definition-list is-grid">
       <dt class="definition-list__term">${label}</dt>

--- a/src/_layouts/components/medium.11ty.js
+++ b/src/_layouts/components/medium.11ty.js
@@ -2,7 +2,7 @@ exports.getMediumOfPainting = (eleventy, { content }, langCode) => {
   const { medium } = content;
   const prefix = content.metadata.id;
   const structuredMediumData = eleventy.getStructuredDataFromString(medium);
-  const visibleContent = structuredMediumData[0].text;
+  const visibleContent = structuredMediumData[0].text.split('<br>')[0];
   const hasAdditionalContent = !!(structuredMediumData.length >= 1 && structuredMediumData[0].remark.match(/[a-z]/));
   const label = eleventy.translate('medium', langCode);
   const remarkDataTableData = {
@@ -27,7 +27,7 @@ exports.getMediumOfGraphic = (eleventy, { content }, langCode) => {
   const { medium } = content;
   const prefix = content.metadata.id;
   const structuredMediumData = eleventy.getStructuredDataFromString(medium);
-  const visibleContent = structuredMediumData[0].text;
+  const visibleContent = structuredMediumData[0].text.split('<br>')[0];
   const hasAdditionalContent = !!(structuredMediumData.length >= 1 && structuredMediumData[0].remark.match(/[a-z]/));
   const label = eleventy.translate('medium', langCode);
   const remarkDataTableData = {

--- a/src/_layouts/components/title.11ty.js
+++ b/src/_layouts/components/title.11ty.js
@@ -4,6 +4,7 @@ exports.getTitle = (eleventy, { content }, langCode) => {
     ? content.titles.map((item) => ({ text: item.title, remark: item.remarks }))
     : [];
   const label = titleList.length > 1 ? eleventy.translate('titles', langCode) : eleventy.translate('title', langCode);
+
   const remarkDataTableData = {
     id: 'Titles',
     content: titleList,
@@ -18,6 +19,3 @@ exports.getTitle = (eleventy, { content }, langCode) => {
     ${allTitles}
   `;
 };
-
-
-


### PR DESCRIPTION
* feat: render mediumData as paragraphs instead of tables
* fix: split visibleContent by `<br>` to ensure correct display in getMediumOfPainting and getMediumOfGraphic