### PR TITLE
Fix buid 226

### DIFF
--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -167,6 +167,26 @@
     "de": "Zuschreibungen",
     "en": "Attributions"
   },
+  "printer": {
+    "de": "Drucker",
+    "en": "Printer"
+  },
+  "printers": {
+    "de": "Drucker",
+    "en": "Printers"
+  },
+  "publisher": {
+    "de": "Verleger",
+    "en": "Publisher"
+  },
+  "publishers": {
+    "de": "Verleger",
+    "en": "Publisher"
+  },
+  "officins": {
+    "de": "Officin",
+    "en": "Officina"
+  },
   "productionDate": {
     "de": "Datierung",
     "en": "Production date"
@@ -439,7 +459,7 @@
     "de": "Zugehörige Werke",
     "en": "Connected Works"
   },
-  "overallViewOfThePiece":{
+  "overallViewOfThePiece": {
     "de": "Gesamtansicht des Werkes",
     "en": "Overall view of the piece"
   },
@@ -574,7 +594,7 @@
   "zur-suche": {
     "de": "zur Suche",
     "en": "go to search"
-  }, 
+  },
   "zur-werksuche": {
     "de": "zur Werksuche",
     "en": "go to works search"
@@ -627,20 +647,19 @@
     "de": "Literatur anzeigen",
     "en": "Show Literature"
   },
-  "worksDiscussedInPublication":{
+  "worksDiscussedInPublication": {
     "de": "In der Publikation besprochene Werke",
     "en": "Works discussed in publication"
   },
-  "IDENTICAL_WATERMARK":
-  {
+  "IDENTICAL_WATERMARK": {
     "de": "Identisches Wasserzeichen",
     "en": "Identical watermark"
   },
-  "ON_SAME_SHEET":{
+  "ON_SAME_SHEET": {
     "de": "Auf dem selben Blatt",
     "en": "On the same sheet"
   },
-  "PART_OF_SERIES":{
+  "PART_OF_SERIES": {
     "de": "Teil einer Serie",
     "en": "Part of series"
   },
@@ -652,13 +671,11 @@
     "de": "Lizenz:",
     "en": "License:"
   },
-
   "licenseText": {
     "de": "Creative Commons Namensnennung 4.0 International",
     "en": "Creative Commons Attribution 4.0 International"
-  }
-  ,
-  "SHOW_ALL":{ 
+  },
+  "SHOW_ALL": {
     "de": "Alle anzeigen",
     "en": "Show all"
   }

--- a/src/_layouts/components/attribution.11ty.js
+++ b/src/_layouts/components/attribution.11ty.js
@@ -12,7 +12,7 @@ exports.getAttribution = (eleventy, { content }, langCode) => {
 
     const fullName = fragments.join(' ');
 
-    if (!entityType.match(/graphics/)) return fullName;
+    if (!entityType || !entityType.match(/graphics/)) return fullName;
 
     const nameAndRole = [];
     nameAndRole.push(fullName);
@@ -44,5 +44,71 @@ exports.getAttribution = (eleventy, { content }, langCode) => {
       </dd>
     </dl>
     ${allAttributions}
+  `;
+};
+
+exports.getPrinter = (eleventy, { content }, langCode) => {
+  const printers = content.involvedPersons.filter((person) => person.roleType === 'PRINTER');
+
+  if (printers.length === 0) return '';
+
+  const label = printers.length > 1 ? eleventy.translate('printers', langCode) : eleventy.translate('printer', langCode);
+  const printerNames = printers.map((person) => {
+    const fragments = [];
+    if (person.prefix) fragments.push(person.prefix);
+    if (person.name) fragments.push(person.name);
+    if (person.suffix) fragments.push(person.suffix);
+    return fragments.join(' ');
+  });
+
+  return `
+    <dl class="definition-list is-grid">
+      <dt class="definition-list__term">${label}</dt>
+      <dd class="definition-list__definition">${printerNames.join('<br>')}</dd>
+    </dl>
+  `;
+};
+
+exports.getPublisher = (eleventy, { content }, langCode) => {
+  const publishers = content.involvedPersons.filter((person) => person.roleType === 'PUBLISHER');
+
+  if (publishers.length === 0) return '';
+
+  const label = publishers.length > 1 ? eleventy.translate('publishers', langCode) : eleventy.translate('publisher', langCode);
+  const publisherNames = publishers.map((person) => {
+    const fragments = [];
+    if (person.prefix) fragments.push(person.prefix);
+    if (person.name) fragments.push(person.name);
+    if (person.suffix) fragments.push(person.suffix);
+    return fragments.join(' ');
+  });
+
+  return `
+    <dl class="definition-list is-grid">
+      <dt class="definition-list__term">${label}</dt>
+      <dd class="definition-list__definition">${publisherNames.join('<br>')}</dd>
+    </dl>
+  `;
+};
+
+exports.getOfficin = (eleventy, { content }, langCode) => {
+  const officins = content.involvedPersons.filter((person) => person.roleType === 'OFFICIN');
+
+  if (officins.length === 0) return '';
+
+  const label = officins.length > 1 ? eleventy.translate('officins', langCode) : eleventy.translate('officin', langCode);
+  const officinNames = officins.map((person) => {
+    const fragments = [];
+    if (person.prefix) fragments.push(person.prefix);
+    if (person.name) fragments.push(person.name);
+    if (person.suffix) fragments.push(person.suffix);
+    return fragments.join(' ');
+  });
+
+  return `
+    <dl class="definition-list is-grid">
+      <dt class="definition-list__term">${label}</dt>
+      <dd class="definition-list__definition">${officinNames.join('<br>')}</dd>
+    </dl>
   `;
 };

--- a/src/_layouts/components/graphic-real-object.11ty.js
+++ b/src/_layouts/components/graphic-real-object.11ty.js
@@ -23,6 +23,7 @@ const referencesSnippet = require('./references.11ty');
 const conditionSnippet = require('./condition.11ty');
 const navigationSnippet = require('./navigation.11ty');
 const datingSnippet = require('./dating.11ty');
+const attributionSnippet = require('./attribution.11ty');
 
 const ART_TECH_EXAMINATION = 'ArtTechExamination';
 const CONDITION_REPORT = 'ConditionReport';
@@ -89,6 +90,10 @@ exports.getRealObject = function (eleventy, pageData, langCode, masterData) {
   const shortDescription = descriptionSnippet.getShortDescription(eleventy, data, langCode);
   const dating = datingSnippet.getDating(eleventy, data, langCode);
 
+  const printer = attributionSnippet.getPrinter(eleventy, data, langCode);
+  const publisher = attributionSnippet.getPublisher(eleventy, data, langCode);
+  const officina = attributionSnippet.getOfficin(eleventy, data, langCode);
+
   const cranachCollectBaseUrl = eleventy.getCranachCollectBaseUrl();
   const cranachCollectScript = config.cranachCollect.script;
 
@@ -132,6 +137,9 @@ exports.getRealObject = function (eleventy, pageData, langCode, masterData) {
             <div class="block">
               ${condition}
               ${dating}
+              ${printer}
+              ${publisher}
+              ${officina}
               ${medium}
               ${shortDescription}
               ${dimensions}

--- a/src/_layouts/graphic-virtual-object-item.11ty.js
+++ b/src/_layouts/graphic-virtual-object-item.11ty.js
@@ -139,7 +139,7 @@ const getReprints = (eleventy, data, conditionLevel, secondConditionLevel = fals
                 <img src="${item.imgSrc}" alt="${title}" loading="lazy">
               </div>
               <figcaption class="artefact-card__content">
-                <p class="artefact-card__text">${item.id}<br>${cardText.join(', ', cardText)}${editionVisibleID}</p>
+                <p class="artefact-card__text"><strong>${cardText.join(', ', cardText)}${editionVisibleID}</strong><br>${item.id}</p>
               </figcaption>
             </a>
           </figure>

--- a/src/_layouts/graphic-virtual-object-item.11ty.js
+++ b/src/_layouts/graphic-virtual-object-item.11ty.js
@@ -233,6 +233,7 @@ exports.render = function (pageData) {
       <div id="page">
         ${navigation}
         ${masterData}
+        
         <section id="reprints" class="leporello-reprints js-main-content">
           <h2 class="leporello-reprints__headline">${this.translate('impressions', langCode)}</h2>
           ${reprintsLevel0} <!-- Unbekannter Zustand -->


### PR DESCRIPTION
Dieser Pull Request behebt einen Teilaspekt von Bug #226.
Konkret wird die Darstellung der Metadaten in der Übersicht der Abzüge auf den Seiten der virtuellen Objekte (Artefakt-Seiten) an die vereinbarte Spezifikation angepasst.
Weitere Teile des Bugs bleiben von diesem Pull Request unberührt.